### PR TITLE
Fix broken link

### DIFF
--- a/learn/transitioning-from-backbone/index.html
+++ b/learn/transitioning-from-backbone/index.html
@@ -63,7 +63,7 @@ model.name = &#39;henrik&#39;; // this still fires a `change:name`
 model.name;
 </code></pre>
 <a name="views" class="anchor" href="#views"><h2><span class="header-link"></span>Views</h2></a><p>Backbone views are pretty sparse, by design. But data binding is something you&#39;re going to have to solve if you don&#39;t want to re-render the whole view, or if you ever want to do individual bindings.</p>
-<p>Ampersand handles this with declarative bindings and subviews. You can read more about that in the <a href="/learn/fetching-data-for-views/">view guide</a>.</p>
+<p>Ampersand handles this with declarative bindings and subviews. You can read more about that in the <a href="/learn/data-bindings-in-views">view guide</a>.</p>
 </section>
       </div><a href="/learn" class="back">Back to Guides</a>
     </div>


### PR DESCRIPTION
The 'view guide' link was pointing to what was probably an old path for that page.
