### PR TITLE
Fix derived property example

### DIFF
--- a/learn_markdown/state.md
+++ b/learn_markdown/state.md
@@ -75,7 +75,7 @@ var DraggedElementModel = State.extend({
             // how it's calculated
             fn: function () {
                 // the distance formula
-                return Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2)) > 10;
+                return Math.sqrt(Math.pow(this.x, 2) + Math.pow(this.y, 2)) > 10;
             }
         }
     }


### PR DESCRIPTION
Adding where `x` and `y` come from.

Initially I thought you guys did some weird eval magic (introducing `x` and `y` into scope), but looking at my scaffolded example app I see the `this` was simply missing. Phew.
