### PR TITLE
fixed doc title issue of being squashed together on same line

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -792,7 +792,7 @@ nav.nav-main .button {
 }
 .docs-content .anchor {
   position: relative;
-  display: inline-block;
+  display: block;
 }
 .docs-content .anchor .header-link {
   width: 20px;

--- a/static/css/sections/docs.styl
+++ b/static/css/sections/docs.styl
@@ -37,7 +37,7 @@
 
   .anchor
     position: relative
-    display: inline-block
+    display: block
 
     .header-link
       width: 20px


### PR DESCRIPTION
As discussed in issue #31, this is a fix to the doc titles by changing the anchors to block rather than inline-block. 
