### PR TITLE
Horizontal scrollbars only appear if needed

### DIFF
--- a/public/styl/components/code.styl
+++ b/public/styl/components/code.styl
@@ -9,7 +9,6 @@ code
   text-rendering: optimizeLegibility
   font-size: $font-size-small
   -webkit-font-smoothing: antialiased
-  overflow-x: scroll  
   white-space: nowrap
   border: none
   padding: .154em .308em
@@ -20,7 +19,6 @@ code
 
 pre
   max-width: 100%
-  overflow-x: scroll
 
   code
     display: block


### PR DESCRIPTION
This fixes https://github.com/AmpersandJS/ampersandjs.com/issues/52.
