### PR TITLE
Typo and code example fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This generates the static site that lives here: http://ampersandjs.com/
 
 ## How it works
 
-The dynamic portions of the site are pulled down from The Internet™. 
+The dynamic portions of the site are pulled down from The Internet™.
 
 Specifically, we use [module-details](https://github.com/HenrikJoreteg/module-details) to fetch and parse complete info about a module from the npm registry.
 
@@ -39,7 +39,7 @@ As of this writing the relevant portion looks like this:
   ...
 ```
 
-The core and form modules are all fetched and dates compared to figure out which are in fact, the most "recent" for use in the home page "recently released" seciton. 
+The core and form modules are all fetched and dates compared to figure out which are in fact, the most "recent" for use in the home page "recently released" section.
 
 The featured modules are grabbed and rendered in order listed in the "featuredModules" section.
 
@@ -58,7 +58,7 @@ This text will not show up in generated docs
 <!-- endhide -->
 ```
 
-It's then converted to HTML and rendered using the jade templates. 
+It's then converted to HTML and rendered using the jade templates.
 
 Perhaps a bit convoluted, but works well enough.
 
@@ -66,7 +66,7 @@ Perhaps a bit convoluted, but works well enough.
 
 These are all in markdown in the `learn_markdown` directory. There's a bit of metadata at the top.
 
-This is the page title (used to generate what the nav calls it) and an `order` value that will be used to sort them all. 
+This is the page title (used to generate what the nav calls it) and an `order` value that will be used to sort them all.
 
 These don't have to be sequential and nothing will blow up if there are two that are the same or whatnot, they're simply run through a sorter that uses that value to attempt to sort them.
 
@@ -93,7 +93,7 @@ npm i -g http-server
 There's a quick and dirty `-w` option that will rebuild if anything changes:
 
 ```
-npm run build -w 
+npm run build -w
 ```
 
 So you can have that in one terminal tab, and just run `http-server` in the root project directory in another tab and you're up and running.

--- a/learn/data-bindings-in-views/index.html
+++ b/learn/data-bindings-in-views/index.html
@@ -20,10 +20,10 @@
         <section><a name="data-and-bindings-in-views" class="anchor" href="#data-and-bindings-in-views"><h1><span class="header-link"></span>Data and bindings in views</h1></a><p>Also, a common question we hear from devs building backbone apps is what a good pattern is for fetching and rendering a single model from a collection for a &quot;detail&quot; page.</p>
 <p>We may want to render the page and get pixels on the screen as soon as possible, but what happens when we don&#39;t have all our data yet. Somehow we have to coordinate this, so that the view is updated as relevant data arrives or properties change.</p>
 <p>Ampersand-view handles this with declarative bindings. The binding declarations are <em>completely</em> decoupled from the data models.</p>
-<p>In the same way you declare a hash of events to listen to from the DOM, ampersand-view lets you declare a hash of bindings to go the other way: from your models to the DOM. You explicitly describe the relationship and then the view handles the rest, no matter when you get your models or data. </p>
+<p>In the same way you declare a hash of events to listen to from the DOM, ampersand-view lets you declare a hash of bindings to go the other way: from your models to the DOM. You explicitly describe the relationship and then the view handles the rest, no matter when you get your models or data.</p>
 <p>This gives you complete flexibility over when you render what.</p>
-<p>You can most certainly use whatever template language you want with ampersand-views, but the nice things is <strong>no template engine is actually necessary in order to get bindings</strong>! </p>
-<p>Your can simply have an HTML string as your <code>template</code> property and declare your bindings and everything Just Works™.</p>
+<p>You can most certainly use whatever template language you want with ampersand-views, but the nice things is <strong>no template engine is actually necessary in order to get bindings</strong>!</p>
+<p>You can simply have an HTML string as your <code>template</code> property and declare your bindings and everything Just Works™.</p>
 <a name="example" class="anchor" href="#example"><h3><span class="header-link"></span>Example</h3></a><p>Here&#39;s an example view pulled from a real app.</p>
 <pre><code class="undefinedjs">var View = require(&#39;ampersand-view&#39;);
 var templates = require(&#39;../templates&#39;);
@@ -60,7 +60,7 @@ module.exports = View.extend({
 </code></pre>
 <p>The nice thing about this approach is, it doesn&#39;t matter if you swap out the <code>model</code> or if you don&#39;t have a <code>model</code> yet. It will still just work.</p>
 <p>This works because ampersand-view also inherits from <a href="http://ampersandjs.com/docs#ampersand-state">ampersand-state</a> and so its <code>model</code> and <code>el</code> properties are evented properties tracked by ampersand-state.</p>
-<a name="subviews" class="anchor" href="#subviews"><h3><span class="header-link"></span>Subviews</h3></a><p>Ampersand-view also has the concept of subviews. Which you can render within a parent view and it will get gracefully removed when the parent is. This makes it easier to split up your views into smaller more reusable pieces. </p>
+<a name="subviews" class="anchor" href="#subviews"><h3><span class="header-link"></span>Subviews</h3></a><p>Ampersand-view also has the concept of subviews. Which you can render within a parent view and it will get gracefully removed when the parent is. This makes it easier to split up your views into smaller more reusable pieces.</p>
 <p>Many internal tools like all the <a href="http://ampersandjs.com/learn/forms">ampersand form tools</a> are meant to work well as subviews. And again, anything can be subview as long as it follows the <a href="http://ampersandjs.com/learn/view-conventions">ampersand view conventions</a> ultimate flexibility and composability, FTW! :)</p>
 <p>You can read more about subviews in the <a href="http://ampersandjs.com/docs#ampersand-view">ampersand-view documentation</a>.</p>
 </section>

--- a/learn/state/index.html
+++ b/learn/state/index.html
@@ -19,7 +19,7 @@
       <div class="docs-content">
         <section><a name="understanding-state" class="anchor" href="#understanding-state"><h1><span class="header-link"></span>Understanding State</h1></a><p>So much of application development is managing relationship between object properties. If you take a step back from your code you can often see that most of it is saying &quot;when this condition and this other condition are met, then this value should be &#39;x&#39;.&quot;</p>
 <p>This is especially true when building user interfaces.</p>
-<p>Stringing together a spaghetti bowl of <code>if</code> statements is a painful way to build a state machine that handles this. </p>
+<p>Stringing together a spaghetti bowl of <code>if</code> statements is a painful way to build a state machine that handles this.</p>
 <p>Often times it&#39;d be easier if we could just declare: &quot;this thing is dependent on these two other things&quot; and from those two other values calculate a value.</p>
 <p>Turns out tracking relationships between values is useful not just for state that comes from a server, but also for lots of other things. For example, in views we want to know if the view is rendered or not or whether it has all the data it needs or not.</p>
 <p>It is for this purpose, that ampersand state was created.</p>
@@ -42,7 +42,7 @@ var person = new Person({name: &#39;henrik&#39;});
 
 // watch it
 person.on(&#39;change:isDancing&#39;, function () {
-    console.log(&#39;shake it!&#39;); 
+    console.log(&#39;shake it!&#39;);
 });
 
 // set the value and the callback will fire
@@ -83,7 +83,7 @@ element.on(&#39;change:dragged&#39;, function (model, val) {
 });
 </code></pre>
 <p>Derived properties aren&#39;t a new idea. But, being able to clearly declare and derive watchable properties from a model is super useful and in our case, the fact that they can be accessed without calling a method keeps things clean. For example, using the draggable example above, the derived property is just <code>element.dragged</code>.</p>
-<p>Note that these can be read but not set directly (trying to set a value of a derived property throws an error). </p>
+<p>Note that these can be read but not set directly (trying to set a value of a derived property throws an error).</p>
 <a name="handling-relationships-between-objectsmodels-with-derived-properties" class="anchor" href="#handling-relationships-between-objectsmodels-with-derived-properties"><h2><span class="header-link"></span>Handling relationships between objects/models with derived properties</h2></a><p>Say you&#39;ve got an observable that you&#39;re using to model data from a RESTful API. Say that you&#39;ve got a <code>/users</code> endpoint and when fetching a user, the user data includes a groupID that links them to another collection of groups that we&#39;ve already fetched and have created local models for. From our user model we want to be able to easily access the related group model so that when rendering a template we can just access related group information.</p>
 <p>Cached, derived properties are perfect for handling this relationship:</p>
 <pre><code class="undefinedjs">var UserModel = State.extend({
@@ -95,7 +95,7 @@ element.on(&#39;change:dragged&#39;, function (model, val) {
         groupModel: {
             deps: [&#39;groupId&#39;],
             fn: function () {
-                // we access our group collection from within 
+                // we access our group collection from within
                 // the derived property to grab the right group model.
                 return ourGroupCollection.get(this.groupId);
             }
@@ -115,13 +115,15 @@ user.on(&#39;change:groupModel&#39;, function (model, newGroupModel) {
 });
 </code></pre>
 <a name="cached-derived-properties-are-awesome" class="anchor" href="#cached-derived-properties-are-awesome"><h2><span class="header-link"></span>Cached, derived properties are awesome</h2></a><p>So, say you have a more &quot;expensive&quot; computation for model. Say you&#39;re parsing a long string for URLs and turning them into HTML and then wanting to reference that later. Again, this is built in.</p>
-<p>By default, derived properties are cached. </p>
+<p>By default, derived properties are cached.</p>
 <pre><code class="undefinedjs">// assume this linkifies strings
 var linkify = require(&#39;urlify&#39;);
 
 var MySmartDescriptionModel = State.extend({
-    // assume this is a long string of text
-    description: &#39;string&#39;,
+    props: {
+      // assume this is a long string of text
+      description: &#39;string&#39;,
+    }
     derived: {
         linkified: {
             deps: [&#39;description&#39;],
@@ -136,13 +138,13 @@ var myDescription = new MySmartDescriptionModel({
     description: &quot;Some text with a link. http://twitter.com/henrikjoreteg&quot;
 });
 
-// Now i can just reference this as many times as I want but it 
+// Now i can just reference this as many times as I want but it
 // will never run it through the expensive function again.
 
 myDescription.linkified;
 </code></pre>
 <p>With the model above, the description will only be run through that linkifier method once, unless of course the description changes.</p>
-<a name="derived-properties-are-intelligently-triggered" class="anchor" href="#derived-properties-are-intelligently-triggered"><h2><span class="header-link"></span>Derived properties are intelligently triggered</h2></a><p>Just because an underlying property has changed, <em>doesn&#39;t mean the derived property has</em>. </p>
+<a name="derived-properties-are-intelligently-triggered" class="anchor" href="#derived-properties-are-intelligently-triggered"><h2><span class="header-link"></span>Derived properties are intelligently triggered</h2></a><p>Just because an underlying property has changed, <em>doesn&#39;t mean the derived property has</em>.</p>
 <p>Cached derived properties will <em>only</em> trigger a <code>change</code> if the resulting calculated value has changed.</p>
 <p>This is <em>super</em> useful if you&#39;ve bound a derived property to a DOM property. This ensures that you won&#39;t ever touch the DOM unless the resulting value is <em>actually</em> different. Avoiding unnecessary DOM changes is a huge boon for performance.</p>
 <p>This is also important for cases where you&#39;re dealing with fast changing attributes.</p>
@@ -171,7 +173,7 @@ var increment = function () {
 setInterval(increment, 50);
 
 data.on(&#39;change:thousandTweets&#39;, function () {
-    // will only get called every time is passes another 
+    // will only get called every time is passes another
     // thousand tweets.
 });
 </code></pre>
@@ -232,7 +234,7 @@ var Person = State.extend({
     }
 });
 
-// When we instantiate an instance of a Person 
+// When we instantiate an instance of a Person
 // the Messages collection and ProfileModels
 // are instantiated as well
 
@@ -254,7 +256,7 @@ var otherPerson = new Person({
         {from: &#39;someoneElse&#39;, message: &#39;yo!&#39;},
     ],
     profile: {
-        name: &#39;Joe&#39;, 
+        name: &#39;Joe&#39;,
         hairColor: &#39;black&#39;
     }
 });
@@ -266,18 +268,18 @@ otherPerson.messages.length === 2; // true
 // populated
 otherPerson.profile.name === &#39;Joe&#39;; // true
 
-// The same works for `set`, it will apply it 
-// to children as well. 
+// The same works for `set`, it will apply it
+// to children as well.
 otherPerson.set({profile: {name: &#39;Mary&#39;}});
 
-// Since this a state object it triggers a `change:name` on 
-// the `profile` object. 
-// In addition, since it&#39;s a child that event propagates 
+// Since this a state object it triggers a `change:name` on
+// the `profile` object.
+// In addition, since it&#39;s a child that event propagates
 // up. More on that below.
 </code></pre>
 <a name="event-bubbling-derived-properties-based-on-children" class="anchor" href="#event-bubbling-derived-properties-based-on-children"><h2><span class="header-link"></span>Event bubbling, derived properties based on children</h2></a><p>Say you want a simple way to listen for any changes that are represented in a template.</p>
-<p>Let&#39;s say you&#39;ve got a <code>person</code> state object with a <code>profile</code> child. You want an easy way to listen for changes to either the base <code>person</code> object or the <code>profile</code>. In fact, you want to listen to anything related to the person object. </p>
-<p>Rather than having to worry about watching the right thing, we do exactly what the browser does to solve this problem: we bubble up the events up the chain. </p>
+<p>Let&#39;s say you&#39;ve got a <code>person</code> state object with a <code>profile</code> child. You want an easy way to listen for changes to either the base <code>person</code> object or the <code>profile</code>. In fact, you want to listen to anything related to the person object.</p>
+<p>Rather than having to worry about watching the right thing, we do exactly what the browser does to solve this problem: we bubble up the events up the chain.</p>
 <p>Now we can listen for deeply nested changes to properties.</p>
 <p>And we can declare derived properties that depend on children. For example:</p>
 <pre><code class="undefinedjs">var Person = State.extend({
@@ -307,7 +309,7 @@ me.on(&#39;change:childsName&#39;, function (model, newValue) {
 // above will be fired (if the resulting derived property is different)
 me.profile.name = &#39;henrik&#39;;
 </code></pre>
-<a name="a-quick-note-about-instanceof-checks" class="anchor" href="#a-quick-note-about-instanceof-checks"><h2><span class="header-link"></span>A quick note about instanceof checks</h2></a><p>With npm and browserify for module deps you can sometimes end up with a situation where, the same <code>state</code> constructor wasn&#39;t used to build a <code>state</code> object. As a result <code>instanceof</code> checks will fail. </p>
+<a name="a-quick-note-about-instanceof-checks" class="anchor" href="#a-quick-note-about-instanceof-checks"><h2><span class="header-link"></span>A quick note about instanceof checks</h2></a><p>With npm and browserify for module deps you can sometimes end up with a situation where, the same <code>state</code> constructor wasn&#39;t used to build a <code>state</code> object. As a result <code>instanceof</code> checks will fail.</p>
 <p>In order to deal with this (because sometimes this is a legitimate scenario), <code>state</code> simply creates a read-only <code>isState</code> property on all state objects that can be used to check</p>
 </section>
       </div><a href="/learn" class="back">Back to Guides</a>

--- a/learn_markdown/data-bindings-in-views.md
+++ b/learn_markdown/data-bindings-in-views.md
@@ -11,13 +11,13 @@ We may want to render the page and get pixels on the screen as soon as possible,
 
 Ampersand-view handles this with declarative bindings. The binding declarations are *completely* decoupled from the data models.
 
-In the same way you declare a hash of events to listen to from the DOM, ampersand-view lets you declare a hash of bindings to go the other way: from your models to the DOM. You explicitly describe the relationship and then the view handles the rest, no matter when you get your models or data. 
+In the same way you declare a hash of events to listen to from the DOM, ampersand-view lets you declare a hash of bindings to go the other way: from your models to the DOM. You explicitly describe the relationship and then the view handles the rest, no matter when you get your models or data.
 
 This gives you complete flexibility over when you render what.
 
-You can most certainly use whatever template language you want with ampersand-views, but the nice things is **no template engine is actually necessary in order to get bindings**! 
+You can most certainly use whatever template language you want with ampersand-views, but the nice things is **no template engine is actually necessary in order to get bindings**!
 
-Your can simply have an HTML string as your `template` property and declare your bindings and everything Just Works™.
+You can simply have an HTML string as your `template` property and declare your bindings and everything Just Works™.
 
 ### Example
 
@@ -65,7 +65,7 @@ This works because ampersand-view also inherits from [ampersand-state](http://am
 
 ### Subviews
 
-Ampersand-view also has the concept of subviews. Which you can render within a parent view and it will get gracefully removed when the parent is. This makes it easier to split up your views into smaller more reusable pieces. 
+Ampersand-view also has the concept of subviews. Which you can render within a parent view and it will get gracefully removed when the parent is. This makes it easier to split up your views into smaller more reusable pieces.
 
 Many internal tools like all the [ampersand form tools](http://ampersandjs.com/learn/forms) are meant to work well as subviews. And again, anything can be subview as long as it follows the [ampersand view conventions](http://ampersandjs.com/learn/view-conventions) ultimate flexibility and composability, FTW! :)
 

--- a/learn_markdown/state.md
+++ b/learn_markdown/state.md
@@ -152,7 +152,7 @@ var MySmartDescriptionModel = State.extend({
     props: {
       // assume this is a long string of text
       description: 'string',
-    }
+    },
     derived: {
         linkified: {
             deps: ['description'],

--- a/learn_markdown/state.md
+++ b/learn_markdown/state.md
@@ -9,7 +9,7 @@ So much of application development is managing relationship between object prope
 
 This is especially true when building user interfaces.
 
-Stringing together a spaghetti bowl of `if` statements is a painful way to build a state machine that handles this. 
+Stringing together a spaghetti bowl of `if` statements is a painful way to build a state machine that handles this.
 
 Often times it'd be easier if we could just declare: "this thing is dependent on these two other things" and from those two other values calculate a value.
 
@@ -43,7 +43,7 @@ var person = new Person({name: 'henrik'});
 
 // watch it
 person.on('change:isDancing', function () {
-    console.log('shake it!'); 
+    console.log('shake it!');
 });
 
 // set the value and the callback will fire
@@ -97,7 +97,7 @@ element.on('change:dragged', function (model, val) {
 
 Derived properties aren't a new idea. But, being able to clearly declare and derive watchable properties from a model is super useful and in our case, the fact that they can be accessed without calling a method keeps things clean. For example, using the draggable example above, the derived property is just `element.dragged`.
 
-Note that these can be read but not set directly (trying to set a value of a derived property throws an error). 
+Note that these can be read but not set directly (trying to set a value of a derived property throws an error).
 
 
 ## Handling relationships between objects/models with derived properties
@@ -116,7 +116,7 @@ var UserModel = State.extend({
         groupModel: {
             deps: ['groupId'],
             fn: function () {
-                // we access our group collection from within 
+                // we access our group collection from within
                 // the derived property to grab the right group model.
                 return ourGroupCollection.get(this.groupId);
             }
@@ -142,15 +142,17 @@ user.on('change:groupModel', function (model, newGroupModel) {
 
 So, say you have a more "expensive" computation for model. Say you're parsing a long string for URLs and turning them into HTML and then wanting to reference that later. Again, this is built in.
 
-By default, derived properties are cached. 
+By default, derived properties are cached.
 
 ```js
 // assume this linkifies strings
 var linkify = require('urlify');
 
 var MySmartDescriptionModel = State.extend({
-    // assume this is a long string of text
-    description: 'string',
+    props: {
+      // assume this is a long string of text
+      description: 'string',
+    }
     derived: {
         linkified: {
             deps: ['description'],
@@ -165,7 +167,7 @@ var myDescription = new MySmartDescriptionModel({
     description: "Some text with a link. http://twitter.com/henrikjoreteg"
 });
 
-// Now i can just reference this as many times as I want but it 
+// Now i can just reference this as many times as I want but it
 // will never run it through the expensive function again.
 
 myDescription.linkified;
@@ -177,7 +179,7 @@ With the model above, the description will only be run through that linkifier me
 
 ## Derived properties are intelligently triggered
 
-Just because an underlying property has changed, *doesn't mean the derived property has*. 
+Just because an underlying property has changed, *doesn't mean the derived property has*.
 
 Cached derived properties will *only* trigger a `change` if the resulting calculated value has changed.
 
@@ -212,7 +214,7 @@ var increment = function () {
 setInterval(increment, 50);
 
 data.on('change:thousandTweets', function () {
-    // will only get called every time is passes another 
+    // will only get called every time is passes another
     // thousand tweets.
 });
 
@@ -291,7 +293,7 @@ var Person = State.extend({
     }
 });
 
-// When we instantiate an instance of a Person 
+// When we instantiate an instance of a Person
 // the Messages collection and ProfileModels
 // are instantiated as well
 
@@ -313,7 +315,7 @@ var otherPerson = new Person({
         {from: 'someoneElse', message: 'yo!'},
     ],
     profile: {
-        name: 'Joe', 
+        name: 'Joe',
         hairColor: 'black'
     }
 });
@@ -325,13 +327,13 @@ otherPerson.messages.length === 2; // true
 // populated
 otherPerson.profile.name === 'Joe'; // true
 
-// The same works for `set`, it will apply it 
-// to children as well. 
+// The same works for `set`, it will apply it
+// to children as well.
 otherPerson.set({profile: {name: 'Mary'}});
 
-// Since this a state object it triggers a `change:name` on 
-// the `profile` object. 
-// In addition, since it's a child that event propagates 
+// Since this a state object it triggers a `change:name` on
+// the `profile` object.
+// In addition, since it's a child that event propagates
 // up. More on that below.
 ```
 
@@ -339,9 +341,9 @@ otherPerson.set({profile: {name: 'Mary'}});
 
 Say you want a simple way to listen for any changes that are represented in a template.
 
-Let's say you've got a `person` state object with a `profile` child. You want an easy way to listen for changes to either the base `person` object or the `profile`. In fact, you want to listen to anything related to the person object. 
+Let's say you've got a `person` state object with a `profile` child. You want an easy way to listen for changes to either the base `person` object or the `profile`. In fact, you want to listen to anything related to the person object.
 
-Rather than having to worry about watching the right thing, we do exactly what the browser does to solve this problem: we bubble up the events up the chain. 
+Rather than having to worry about watching the right thing, we do exactly what the browser does to solve this problem: we bubble up the events up the chain.
 
 Now we can listen for deeply nested changes to properties.
 
@@ -379,6 +381,6 @@ me.profile.name = 'henrik';
 
 ## A quick note about instanceof checks
 
-With npm and browserify for module deps you can sometimes end up with a situation where, the same `state` constructor wasn't used to build a `state` object. As a result `instanceof` checks will fail. 
+With npm and browserify for module deps you can sometimes end up with a situation where, the same `state` constructor wasn't used to build a `state` object. As a result `instanceof` checks will fail.
 
-In order to deal with this (because sometimes this is a legitimate scenario), `state` simply creates a read-only `isState` property on all state objects that can be used to check 
+In order to deal with this (because sometimes this is a legitimate scenario), `state` simply creates a read-only `isState` property on all state objects that can be used to check


### PR DESCRIPTION
Typo and code example fixes. Also removed trailing whitespaces. Maybe you guys should enable that in your editors ;)

Most important fix, is the change I made in `learn_markdown/state.md` at line 123.
