### PR TITLE
fix typo

### DIFF
--- a/learn_markdown/transitioning-from-backbone.md
+++ b/learn_markdown/transitioning-from-backbone.md
@@ -67,7 +67,7 @@ Using it from another file
 `client/some-other-file.js`
 
 ```js
-var MyModel = require('./models/model');
+var MyModel = require('./models/my-model');
 
 
 var model = new MyModel();


### PR DESCRIPTION
file name was `client/models/my-model.js` but require statement was `require('./models/model')`
