### PR TITLE
Avoid redirect from npmjs.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,17 +56,17 @@
           <div class="module-card">
             <h4 class="module-name">ampersand-state</h4>
             <p class="module-version">v4.3.12 – Oct 06, 2014</p>
-            <p class="module-links"><a href="https://github.com/ampersandjs/ampersand-state">github</a><a href="https://npmjs.org/package/ampersand-state">npm</a></p>
+            <p class="module-links"><a href="https://github.com/ampersandjs/ampersand-state">github</a><a href="https://www.npmjs.org/package/ampersand-state">npm</a></p>
           </div>
           <div class="module-card">
             <h4 class="module-name">ampersand-dom-bindings</h4>
             <p class="module-version">v3.2.0 – Oct 03, 2014</p>
-            <p class="module-links"><a href="https://github.com/ampersandjs/ampersand-dom-bindings">github</a><a href="https://npmjs.org/package/ampersand-dom-bindings">npm</a></p>
+            <p class="module-links"><a href="https://github.com/ampersandjs/ampersand-dom-bindings">github</a><a href="https://www.npmjs.org/package/ampersand-dom-bindings">npm</a></p>
           </div>
           <div class="module-card">
             <h4 class="module-name">ampersand</h4>
             <p class="module-version">v2.0.1 – Sep 26, 2014</p>
-            <p class="module-links"><a href="https://github.com/ampersandjs/ampersand">github</a><a href="https://npmjs.org/package/ampersand">npm</a></p>
+            <p class="module-links"><a href="https://github.com/ampersandjs/ampersand">github</a><a href="https://www.npmjs.org/package/ampersand">npm</a></p>
           </div><a href="/contribute" class="button button-primary">How to contribute</a>
         </div>
       </div>
@@ -94,21 +94,21 @@
             <h4 class="module-name">bows</h4>
             <p class="module-author">by Philip Roberts</p>
             <p class="module-description">Rainbowed console logs for chrome, opera and firefox in development.</p>
-            <p class="module-links"><a href="https://github.com/latentflip/bows">github</a><a href="https://npmjs.org/package/bows">npm</a>
+            <p class="module-links"><a href="https://github.com/latentflip/bows">github</a><a href="https://www.npmjs.org/package/bows">npm</a>
             </p>
           </div>
           <div class="module-card">
             <h4 class="module-name">bind-transforms</h4>
             <p class="module-author">by Henrik Joreteg</p>
             <p class="module-description">Bind models properties to properly prefixed CSS transforms in backbone/humanjs views.</p>
-            <p class="module-links"><a href="https://github.com/HenrikJoreteg/bind-transforms">github</a><a href="https://npmjs.org/package/bind-transforms">npm</a>
+            <p class="module-links"><a href="https://github.com/HenrikJoreteg/bind-transforms">github</a><a href="https://www.npmjs.org/package/bind-transforms">npm</a>
             </p>
           </div>
           <div class="module-card">
             <h4 class="module-name">getusermedia</h4>
             <p class="module-author">by Henrik Joreteg</p>
             <p class="module-description">cross-browser getUserMedia shim with node.js style error-first API.</p>
-            <p class="module-links"><a href="https://github.com/HenrikJoreteg/getUserMedia">github</a><a href="https://npmjs.org/package/getusermedia">npm</a>
+            <p class="module-links"><a href="https://github.com/HenrikJoreteg/getUserMedia">github</a><a href="https://www.npmjs.org/package/getusermedia">npm</a>
             </p>
           </div>
         </div><a href="/contribute" class="button button-primary">View all modules</a>

--- a/intro.md
+++ b/intro.md
@@ -11,7 +11,7 @@ We love Backbone.js at [&yet](http://andyet.com). It’s brilliantly simple code
 
 We built our first app on Backbone 0.3.1 and have been a user/supporter of the project for quite some time and was honored to have spoken at the first BackboneConf.
 
-Shortly after discovering Backbone, we also got into node.js which brought with it a module approach and eventually an awesome way of managing dependencies that we've have fallen deeply in like with: [npm](https://npmjs.org).
+Shortly after discovering Backbone, we also got into node.js which brought with it a module approach and eventually an awesome way of managing dependencies that we've have fallen deeply in like with: [npm](https://www.npmjs.org).
 
 Nothing has done more for our team’s ability to write clean, maintainable client-side applications than having a really awesome dependency management system and [substack’s](http://twitter.com/substack) [browserify](http://browserify.org/) that allows us to quickly declare/install external dependencies and know that things will Just Work™.
 

--- a/learn/npm-browserify-and-modules/index.html
+++ b/learn/npm-browserify-and-modules/index.html
@@ -77,10 +77,10 @@
 </li>
 </ul>
 <p>The following sections go into more detail about the components, and tools you might use. If you&#39;ve experience with node.js and writing commonjs modules, you can skip straight to <a href="#browserify">browserify</a>.</p>
-<a name="npm" class="anchor" href="#npm"><h2><span class="header-link"></span>npm</h2></a><p><a href="http://npmjs.org">npm</a> is the official package manager for node.js.</p>
+<a name="npm" class="anchor" href="#npm"><h2><span class="header-link"></span>npm</h2></a><p><a href="http://www.npmjs.org">npm</a> is the official package manager for node.js.</p>
 <p>The various components of npm are:</p>
 <ul>
-<li><strong>A registry</strong>. The main one is <a href="https://www.npmjs.org/">http://npmjs.org</a>, but there are others and you can even install private registries if you wish. This is where you can publish modules to, and install modules from. All the ampersand modules are available on the public npm registry. e.g.: <a href="https://www.npmjs.org/package/ampersand-view">https://www.npmjs.org/package/ampersand-view</a></li>
+<li><strong>A registry</strong>. The main one is <a href="https://www.npmjs.org/">http://www.npmjs.org</a>, but there are others and you can even install private registries if you wish. This is where you can publish modules to, and install modules from. All the ampersand modules are available on the public npm registry. e.g.: <a href="https://www.npmjs.org/package/ampersand-view">https://www.npmjs.org/package/ampersand-view</a></li>
 <li><strong>The npm cli (command line tool)</strong>. This is what you install locally, and run from your command line as <code>npm</code>. This helps you <code>npm install</code> dependencies from the registry, <code>npm publish</code> dependencies, and so on.</li>
 <li><strong>package.json</strong>. Every project that is either published to an npm registry, or installs dependencies from it, should have a package.json. This file defines a few things about the project (name, versions, maintainers, etc) as well as listing any npm modules that the project depends on, and their versions.</li>
 <li><strong>node_modules</strong>. This is a directory that will be created in your project, and is where your npm modules will be installed into. It&#39;s also where node looks for modules when you <code>require()</code> them.</li>

--- a/learn_markdown/npm-browserify-and-modules.md
+++ b/learn_markdown/npm-browserify-and-modules.md
@@ -73,10 +73,10 @@ The following sections go into more detail about the components, and tools you m
 
 ## npm
 
-[npm](http://npmjs.org) is the official package manager for node.js.
+[npm](http://www.npmjs.org) is the official package manager for node.js.
 
 The various components of npm are:
-* **A registry**. The main one is [http://npmjs.org](https://www.npmjs.org/), but there are others and you can even install private registries if you wish. This is where you can publish modules to, and install modules from. All the ampersand modules are available on the public npm registry. e.g.: [https://www.npmjs.org/package/ampersand-view](https://www.npmjs.org/package/ampersand-view)
+* **A registry**. The main one is [http://www.npmjs.org](https://www.npmjs.org/), but there are others and you can even install private registries if you wish. This is where you can publish modules to, and install modules from. All the ampersand modules are available on the public npm registry. e.g.: [https://www.npmjs.org/package/ampersand-view](https://www.npmjs.org/package/ampersand-view)
 * **The npm cli (command line tool)**. This is what you install locally, and run from your command line as `npm`. This helps you `npm install` dependencies from the registry, `npm publish` dependencies, and so on.
 * **package.json**. Every project that is either published to an npm registry, or installs dependencies from it, should have a package.json. This file defines a few things about the project (name, versions, maintainers, etc) as well as listing any npm modules that the project depends on, and their versions.
 * **node_modules**. This is a directory that will be created in your project, and is where your npm modules will be installed into. It's also where node looks for modules when you `require()` them.


### PR DESCRIPTION
``` bash
$ curl --head npmjs.org
HTTP/1.1 301 Moved Permanently
Server: nginx/1.4.6 (Ubuntu)
Date: Sat, 11 Oct 2014 16:58:25 GMT
Content-Type: text/html
Content-Length: 193
Connection: close
Location: https://www.npmjs.org/
```
