### PR TITLE
Adding more detailed security process and make /security work

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,50 @@
-# How to contact us
-Please send any bug that you feel impacts the security of this project to **security@andyet.net**
 
-# Expectations
-You will receive acknowledgment of your report within **24 hours** and a more detailed followup within *48 hours* once we have had time to look into the issue further.
+# Reporting a Security Bug
+      
+All security bugs in AmpersandJS are taken seriously and should be reported by email to **[security@ampersandjs.com](mailto:security@ampersandjs.com)**. This will be delivered to a subset of the core team who handle security issues.
+
+Your email will be acknowledged within 24 hours, and you’ll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report.
+
+After the initial reply to your report, the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement, and may ask for additional information or guidance surrounding the reported issue. These updates will be sent at least every five days, in practice, this is more likely to be every 24-48 hours.
 
 If we have not responded promptly we ask that you give us the benefit of the doubt as it is possible the email went to spam or we have been so focused on something else we haven't seen it yet.  Please send us a quick message, *without detail* at one of the following.
 
-- Email [Adam Baldwin](mailto:baldwin@andyet.net), the &yet CSO directly.
-- Message [@andyet](https://twitter.com/andyet) on twitter.
-- Give our ops team a heads up on IRC in #&yet on irc.freenode.net
+- Contact the current security coordinator ([Adam Baldwin](mailto:baldwin@andyet.net)) directly.
+- Give a heads up in the [chatroom](https://gitter.im/AmpersandJS/AmpersandJS)
+- Message [@ampersandjs](https://twitter.com/ampersandjs) on twitter.
+
+Security bugs in third party modules should be reported to their respective maintainers and can also be coordinated through the [Node Security Project](https://nodesecurity.io).
+
+Thank you for improving the security of AmpersandJS. Your efforts and coordinated disclosure are greatly appreciated and will be acknowledged.
+
+
+# Disclosure Policy
+
+Here is the security disclosure policy for AmpersandJS
+
+- The security report is received and is assigned a primary handler. This person will coordinate the fix and release process. The problem is confirmed and a list of all affected versions is determined. Code is audited to find any potential similar problems. Fixes are prepared for all releases which are still under maintenance. These fixes are not committed to the public repository but rather held locally pending the announcement.
+
+- A suggested embargo date for this vulnerability is chosen and a CVE (Common Vulnerabilities and  Exposures (CVE®)) is requested for the vulnerability.
+
+- On the embargo date, the Node Securty Project will publish the advisory. The changes are pushed to the public repository. 
+
+- Typically the embargo date will be set 72 hours from the time the CVE is issued. However, this may vary depending on the severity of the bug or difficulty in applying a fix.
+
+- This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however, it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.
+
+
+# Receiving Security Updates
+
+Security notifications will be distributed via the following methods.
+
+- A message will be posted in the [chatroom](https://gitter.im/AmpersandJS/AmpersandJS)
+- A security advisory will be published at nodesecurity.io and will be identifiable by the [nsp](https://www.npmjs.org/package/nsp) utility.
+
+# Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a [pull request](https://github.com/AmpersandJS/ampersandjs.com) or email [security@ampersandjs.com](mailto:security@ampersandjs.com) to discuss.
+
 
 # History
+
 No security issues have been reported for this project yet.

--- a/build.js
+++ b/build.js
@@ -111,6 +111,9 @@ function build() {
         contributors: contributors,
         coreContributors: coreContributors
     });
+
+    // Render security page
+    renderJade(__dirname + '/security.jade', {}, __dirname + '/security/index.html');
 }
 
 // optional watcher

--- a/security.jade
+++ b/security.jade
@@ -1,0 +1,20 @@
+block vars
+  - var pageTitle = "Security"
+  - var description = "Ampersand.js, Javascript, ampersand, Node.js, Apps, HTML5"
+
+extends templates/layout
+
+block content
+
+  header.hero
+    .illustration.beach
+      img(src="/public/images/ampersand-at-the-beach.svg")
+    h1 Security is a core value
+
+
+  hr
+
+  section.splash
+
+    .container.cf
+      include:md ./SECURITY.md

--- a/security/index.html
+++ b/security/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Ampersand.js, Javascript, ampersand, Node.js, Apps, HTML5">
+    <meta name="author" content="Ampersand.js, Javascript, ampersand, Node.js, Apps, HTML5">
+    <title>Ampersand.js - Security</title>
+    <link rel="stylesheet" href="//cloud.typography.com/7773252/613684/css/fonts.css">
+    <link rel="stylesheet" href="/public/css/normalize.min.css">
+    <link rel="stylesheet" href="/public/css/main.css">
+    <script>
+      !function(g,s,q,r,d){r=g[r]=g[r]||function(){(r.q=r.q||[]).push(
+      arguments)};d=s.createElement(q);q=s.getElementsByTagName(q)[0];
+      d.src='//d1l6p2sc9645hc.cloudfront.net/tracker.js';q.parentNode.
+      insertBefore(d,q)}(window,document,'script','_gs');
+      _gs('GSN-375569-B', false);
+      _gs('set', 'cookieDomain', '.ampersandjs.com');
+      _gs('track');
+    </script>
+  </head>
+  <body class="undefined">
+    <nav class="nav-main cf"><a href="/" class="logo logo-ampersand">Ampersand.js</a><a href="/learn" class="nav-item">Learn</a><a href="/docs" class="nav-item">Docs</a><a href="http://tools.ampersandjs.com" class="nav-item external">Find Modules</a><a href="https://gitter.im/AmpersandJS/AmpersandJS" class="nav-item external">Chatroom</a><a href="https://trello.com/b/UxylNzHr/ampersand-js-roadmap" class="nav-item external">Roadmap</a><a href="/contribute" class="nav-item">Contribute</a><a href="/learn/quick-start-guide/" class="button button-primary">Get Started</a></nav>
+    <header class="hero">
+      <div class="illustration beach"><img src="/public/images/ampersand-at-the-beach.svg"></div>
+      <h1>Security is a core value</h1>
+    </header>
+    <hr>
+    <section class="splash">
+      <div class="container cf"><h1 id="reporting-a-security-bug">Reporting a Security Bug</h1>
+<p>All security bugs in AmpersandJS are taken seriously and should be reported by email to <strong><a href="mailto:security@ampersandjs.com">security@ampersandjs.com</a></strong>. This will be delivered to a subset of the core team who handle security issues.</p>
+<p>Your email will be acknowledged within 24 hours, and you’ll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report.</p>
+<p>After the initial reply to your report, the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement, and may ask for additional information or guidance surrounding the reported issue. These updates will be sent at least every five days, in practice, this is more likely to be every 24-48 hours.</p>
+<p>If we have not responded promptly we ask that you give us the benefit of the doubt as it is possible the email went to spam or we have been so focused on something else we haven&#39;t seen it yet.  Please send us a quick message, <em>without detail</em> at one of the following.</p>
+<ul>
+<li>Contact the current security coordinator (<a href="mailto:baldwin@andyet.net">Adam Baldwin</a>) directly.</li>
+<li>Give a heads up in the <a href="https://gitter.im/AmpersandJS/AmpersandJS">chatroom</a></li>
+<li>Message <a href="https://twitter.com/ampersandjs">@ampersandjs</a> on twitter.</li>
+</ul>
+<p>Security bugs in third party modules should be reported to their respective maintainers and can also be coordinated through the <a href="https://nodesecurity.io">Node Security Project</a>.</p>
+<p>Thank you for improving the security of AmpersandJS. Your efforts and coordinated disclosure are greatly appreciated and will be acknowledged.</p>
+<h1 id="disclosure-policy">Disclosure Policy</h1>
+<p>Here is the security disclosure policy for AmpersandJS</p>
+<ul>
+<li><p>The security report is received and is assigned a primary handler. This person will coordinate the fix and release process. The problem is confirmed and a list of all affected versions is determined. Code is audited to find any potential similar problems. Fixes are prepared for all releases which are still under maintenance. These fixes are not committed to the public repository but rather held locally pending the announcement.</p>
+</li>
+<li><p>A suggested embargo date for this vulnerability is chosen and a CVE (Common Vulnerabilities and  Exposures (CVE®)) is requested for the vulnerability.</p>
+</li>
+<li><p>On the embargo date, the Node Securty Project will publish the advisory. The changes are pushed to the public repository. </p>
+</li>
+<li><p>Typically the embargo date will be set 72 hours from the time the CVE is issued. However, this may vary depending on the severity of the bug or difficulty in applying a fix.</p>
+</li>
+<li><p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however, it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
+</li>
+</ul>
+<h1 id="receiving-security-updates">Receiving Security Updates</h1>
+<p>Security notifications will be distributed via the following methods.</p>
+<ul>
+<li>A message will be posted in the <a href="https://gitter.im/AmpersandJS/AmpersandJS">chatroom</a></li>
+<li>A security advisory will be published at nodesecurity.io and will be identifiable by the <a href="https://www.npmjs.org/package/nsp">nsp</a> utility.</li>
+</ul>
+<h1 id="comments-on-this-policy">Comments on this Policy</h1>
+<p>If you have suggestions on how this process could be improved please submit a <a href="https://github.com/AmpersandJS/ampersandjs.com">pull request</a> or email <a href="mailto:security@ampersandjs.com">security@ampersandjs.com</a> to discuss.</p>
+<h1 id="history">History</h1>
+<p>No security issues have been reported for this project yet.</p>
+
+      </div>
+    </section>
+    <footer class="footer-main">
+      <nav class="nav-footer"><a href="/learn" class="nav-item">Learn</a><a href="/docs" class="nav-item">Docs</a><a href="http://tools.ampersandjs.com" class="nav-item">Find Modules</a><a href="/contribute" class="nav-item">Contribute</a><a href="https://github.com/ampersandjs" class="nav-item">Github</a><a href="https://twitter.com/ampersandjs" class="nav-item">Twitter</a><a href="https://gitter.im/AmpersandJS/AmpersandJS" class="nav-item external">Chatroom</a><a href="https://trello.com/b/UxylNzHr/ampersand-js-roadmap" class="nav-item external">Roadmap</a><a href="/security" class="nav-item">Security</a></nav>
+      <p>Sponsored by <a href="https://andyet.com">&amp;yet </a><br>with the help of our <a href="/contribute">contributors</a></p><a href="/" class="logo logo-ampersand-gray">&amp;</a>
+    </footer>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-44685415-1', 'humanjavascript.com');
+      ga('send', 'pageview');
+      
+    </script>
+    <script src="/public/js/highlight.pack.js"></script>
+    <script>
+      hljs.configure({classPrefix: ''});
+      hljs.initHighlightingOnLoad();
+      
+    </script>
+  </body>
+</html>

--- a/templates/layout.jade
+++ b/templates/layout.jade
@@ -48,6 +48,7 @@ html(lang="en")
         a.nav-item(href="https://twitter.com/ampersandjs") Twitter
         a.nav-item.external(href="https://gitter.im/AmpersandJS/AmpersandJS") Chatroom
         a.nav-item.external(href="https://trello.com/b/UxylNzHr/ampersand-js-roadmap") Roadmap
+        a.nav-item(href="/security") Security
       p Sponsored by 
         a(href="https://andyet.com") &amp;yet 
         br


### PR DESCRIPTION
My thought is to get a security & from @lynnandtonic for the security page but left the beach in there as a placeholder. Please read and let me know what you think. From there we can modify the security.md's for the other projects to match this more detailed process.

The build works from the security.md file and the security.jade just includes that so it's only needed to be edited in the one place. magic.

Also note that the email addresses referenced might not be created yet until the internal ops request is finished.
