### PR TITLE
Remove gulp-browserify link

### DIFF
--- a/learn_markdown/npm-browserify-and-modules.md
+++ b/learn_markdown/npm-browserify-and-modules.md
@@ -226,7 +226,7 @@ If you're doing it this way, you may find [watchify](https://github.com/substack
 
 #### as part of grunt/gulp
 
-If you use [grunt](http://gruntjs.com/) or [gulp](http://gulpjs.com/), there are plenty of browserify plugins for each to run browserify as part of your build. e.g: [grunt-browserify](https://github.com/jmreidy/grunt-browserify) and [gulp-browserify](https://github.com/deepak1556/gulp-browserify)
+If you use [grunt](http://gruntjs.com/) or [gulp](http://gulpjs.com/), there are plenty of plugins and recipes for each to run browserify as part of your build. e.g: [grunt-browserify](https://github.com/jmreidy/grunt-browserify) and [Browserify+Uglify gulp recipe](https://github.com/gulpjs/gulp/blob/master/docs/recipes/browserify-uglify-sourcemap.md)
 
 #### beefy
 


### PR DESCRIPTION
This is in reference to [#132](https://github.com/AmpersandJS/ampersandjs.com/issues/132)

Removed link to gulp-browserify, and replaced with a link to a browserify recipe from the gulp team.
