### PR TITLE
Use double quotes for .ampersandrc (Fixes AmpersandJS/ampersand#92)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,28 +63,28 @@ my-model-collection.js
 <p>The available options and defaults are as follows:</p>
 <pre><code class="javascript">{
     // default framework to be prompted with, options are express or hapi
-    framework: &#39;hapi&#39;,
-    indent: 4,
-    view: &#39;&#39;, // default template
-    router: &#39;&#39;, // default template
-    model: &#39;&#39;, // default template
-    page: &#39;&#39;, // default template
-    collection: &#39;&#39;, // default template
-    clientfolder: &#39;client&#39;,
-    viewfolder: &#39;views&#39;,
-    pagefolder: &#39;pages&#39;,
-    modelfolder: &#39;models&#39;,
-    formsfolder: &#39;forms&#39;,
-    collectionfolder: &#39;models&#39;,
+    "framework": "hapi",
+    "indent": 4,
+    "view": "", // default template
+    "router": "", // default template
+    "model": "", // default template
+    "page": "", // default template
+    "collection": "", // default template
+    "clientfolder": "client",
+    "viewfolder": "views",
+    "pagefolder": "pages",
+    "modelfolder": "models",
+    "formsfolder": "forms",
+    "collectionfolder": "models",
     // whether to create collection when making a model
-    makecollection: true,
+    "makecollection": true,
     // if it was called without the &#39;gen&#39; argument we&#39;re building a new one
     // so we won&#39;t look for an application root
-    approot: &#39;&#39;, // starts walking up folders looking for package.json
-    f: false, // overwrite
-    force: false, // overwrite flag, longform
-    quotes: &#39;single&#39; // can be &#39;single&#39; or &#39;double&#39;
-};
+    "approot": "", // starts walking up folders looking for package.json
+    "f": false, // overwrite
+    "force": false, // overwrite flag, longform
+    "quotes": "single" // can be "single" or "double"
+}
 </code></pre>
 </div>
         </section>


### PR DESCRIPTION
`&#39;` is used for the single quote, I have replaced them by straight up ", not sure if you wanted to use htmlentities for them instead?
