### PR TITLE
Fix small code typo in ampersand-dom-bindings section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2405,7 +2405,7 @@ module.exports = View.extend({
         // for the property that&#39;s directly on the view
         &#39;activetab&#39;: {
             type: &#39;switch&#39;,
-            case: {
+            cases: {
                 &#39;edit&#39;: &#39;#edit_tab&#39;,
                 &#39;new&#39;: &#39;#new_tab&#39;,
                 &#39;details&#39;: &#39;#details_tab&#39;


### PR DESCRIPTION
Came across this small typo while reading the docs. Should be `cases` not `case`.